### PR TITLE
Refactor magazine site with glassy dark aesthetic

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -1,170 +1,372 @@
 <script>
 	import { slide } from 'svelte/transition';
-    let { children } = $props();
+
+	let { children } = $props();
 
 	let menuOpen = $state(false);
-	let seccionesOpen = $state(false);
-	let visible = $state(false);
 	let showDropdown = $state(false);
-	let hideTimeout;
 
-	function openDropdown() {
-		clearTimeout(hideTimeout);
-		showDropdown = true;
-	}
+	const sections = [
+		{
+			href: '/justicia',
+			label: 'Justicia',
+			description: 'Derechos, ciudadanía y acceso a la justicia',
+			color: '#3C8063'
+		},
+		{
+			href: '/desarrollo',
+			label: 'Desigualdad',
+			description: 'Economía popular, trabajo y territorios',
+			color: '#88378C'
+		},
+		{
+			href: '/cultura',
+			label: 'Cultura',
+			description: 'Artes, identidad y memorias en disputa',
+			color: '#4F449E'
+		},
+		{
+			href: '/politica',
+			label: 'Política',
+			description: 'Poder, democracia y horizontes colectivos',
+			color: '#C44949'
+		},
+		{
+			href: '/medio-ambiente',
+			label: 'Ambiente',
+			description: 'Clima, extractivismo y justicia ambiental',
+			color: '#B13E3E'
+		}
+	];
 
-	function delayedCloseDropdown() {
-		hideTimeout = setTimeout(() => {
-			showDropdown = false;
-		}, 300);
-	}
+	const mainLinks = [
+		{ href: '/nosotros', label: 'Nosotros' },
+		{ href: '/contacto', label: 'Contacto' }
+	];
 
 	$effect(() => {
-		if (typeof window !== 'undefined') {
-			requestIdleCallback(() => {
-				visible = true;
-			});
-		}
-	});
+		if (!menuOpen || typeof window === 'undefined') return;
 
-    let sections = [
-        { href: '/justicia', label: 'Justicia', color: '#3C8063' },
-        { href: '/desarrollo', label: 'Desigualdad', color: '#88378C' },
-        { href: '/cultura', label: 'Cultura', color: '#4F449E' },
-        { href: '/politica', label: 'Política', color: '#C44949' },
-        { href: '/medio-ambiente', label: 'Ambiente', color: '#B13E3E' }
-    ];
+		const handleKeydown = (event) => {
+			if (event.key === 'Escape') {
+				menuOpen = false;
+			}
+		};
+
+		window.addEventListener('keydown', handleKeydown);
+		return () => window.removeEventListener('keydown', handleKeydown);
+	});
 </script>
 
-<nav class="bg-[#374993] text-white shadow-md sticky top-0 z-50 backdrop-blur-sm">
-	<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-		<div class="flex justify-between items-center h-16">
-			<!-- Logo -->
-				<div class="h-14 w-14 mr-3">
-					<img
-						src="/logo.png"
-						alt="Surcos Logo"
-					/>
+<div class="relative min-h-screen bg-slate-950 text-slate-100">
+	<nav class="pointer-events-none fixed inset-x-0 top-0 z-50">
+		<div class="pointer-events-auto mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+			<div
+				class="mt-6 flex items-center justify-between rounded-3xl border border-white/10 bg-slate-900/70 px-5 py-4 shadow-2xl shadow-black/40 backdrop-blur-2xl"
+			>
+				<a href="/" class="flex items-center gap-3">
+					<span
+						class="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/5"
+					>
+						<img src="/logo.png" alt="Surcos" class="h-9 w-9" />
+					</span>
+					<div class="flex flex-col">
+						<span class="font-['Space_Grotesk'] text-lg font-semibold tracking-tight text-white"
+							>Surcos</span
+						>
+						<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-white/60 uppercase"
+							>Revista Digital</span
+						>
+					</div>
+				</a>
+
+				<div class="hidden items-center gap-2 lg:flex">
+					<div
+						class="relative"
+						role="presentation"
+						onmouseenter={() => (showDropdown = true)}
+						onmouseleave={() => (showDropdown = false)}
+						onfocusin={() => (showDropdown = true)}
+						onfocusout={() => (showDropdown = false)}
+					>
+						<button
+							class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium tracking-wide text-white transition hover:border-white/30 hover:bg-white/10"
+							aria-haspopup="true"
+							aria-controls="secciones-menu"
+							aria-expanded={showDropdown}
+						>
+							<span>Secciones</span>
+							<svg
+								class={`h-4 w-4 transition-transform ${showDropdown ? 'rotate-180' : ''}`}
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.5"
+							>
+								<path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"></path>
+							</svg>
+						</button>
+
+						{#if showDropdown}
+							<div
+								class="absolute right-0 z-30 mt-4 w-96 rounded-3xl border border-white/10 bg-slate-900/95 p-4 shadow-2xl shadow-black/40 backdrop-blur-2xl"
+								id="secciones-menu"
+							>
+								<div class="grid gap-3">
+									{#each sections as section (section.href)}
+										<a
+											href={section.href}
+											class="group flex items-start gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3 transition hover:border-white/30 hover:bg-white/10"
+											style={`box-shadow: 0 12px 30px -18px ${section.color}bb;`}
+										>
+											<span
+												class="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl border border-white/10"
+												style={`background:${section.color}1a; color:${section.color};`}
+											>
+												<span class="h-2.5 w-2.5 rounded-full" style={`background:${section.color}`}
+												></span>
+											</span>
+											<span class="flex flex-col">
+												<span class="font-['Space_Grotesk'] text-sm font-semibold text-white"
+													>{section.label}</span
+												>
+												<span class="font-['DM_Sans'] text-xs text-white/70"
+													>{section.description}</span
+												>
+											</span>
+										</a>
+									{/each}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					{#each mainLinks as link (link.href)}
+						<a
+							href={link.href}
+							class="rounded-full border border-white/10 px-4 py-2 text-sm font-medium tracking-wide text-white/80 transition hover:border-white/30 hover:text-white"
+						>
+							{link.label}
+						</a>
+					{/each}
+
+					<a
+						href="/newsletter"
+						class="rounded-full bg-white px-4 py-2 text-sm font-semibold tracking-[0.18em] text-slate-900 uppercase transition hover:bg-slate-100"
+					>
+						Newsletter
+					</a>
 				</div>
 
-			<!-- Desktop Navigation -->
-			<div class="hidden md:flex items-center space-x-6">
-				<!-- Dropdown Menu -->
-				<div
-					class="relative group"
-                    role="button"
-                    tabindex="0"
-					onmouseenter={openDropdown}
-					onmouseleave={delayedCloseDropdown}
+				<button
+					class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white transition hover:border-white/30 hover:bg-white/10 lg:hidden"
+					onclick={() => (menuOpen = !menuOpen)}
+					aria-label="Abrir menú"
+					aria-expanded={menuOpen}
 				>
-					<button
-						class="flex items-center px-3 py-2 rounded-md hover:bg-white/10 transition font-medium font-['Space_Grotesk']"
-						aria-haspopup="true"
-						aria-controls="dropdown-menu"
-						aria-expanded={showDropdown}
+					<svg
+						class={`h-5 w-5 transition-transform ${menuOpen ? 'rotate-90' : ''}`}
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.5"
 					>
-						<span>Secciones</span>
-						<svg class={`w-4 h-4 ml-1 transition-transform duration-200 ${showDropdown ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-						</svg>
-					</button>
+						{#if menuOpen}
+							<path d="M6 6l12 12M6 18L18 6" stroke-linecap="round"></path>
+						{:else}
+							<path d="M4 7h16M4 12h16M4 17h16" stroke-linecap="round"></path>
+						{/if}
+					</svg>
+				</button>
+			</div>
+		</div>
+	</nav>
 
-					{#if showDropdown}
-						<div
-							in:slide={{ y: -10, duration: 250 }}
-							out:slide={{ y: -10, duration: 200 }}
-							class="absolute top-full left-0 mt-2 w-56 bg-white rounded-xl shadow-xl border border-gray-100 z-20"
-							id="dropdown-menu"
+	{#if menuOpen}
+		<div class="fixed inset-0 z-40 lg:hidden">
+			<button
+				type="button"
+				class="absolute inset-0 h-full w-full cursor-pointer bg-slate-950/80 backdrop-blur-xl"
+				aria-label="Cerrar menú"
+				onclick={() => (menuOpen = false)}
+			></button>
+			<div class="relative mx-4 mt-28" in:slide={{ duration: 250 }} out:slide={{ duration: 200 }}>
+				<div
+					class="space-y-6 rounded-3xl border border-white/10 bg-slate-900/95 p-6 shadow-2xl shadow-black/40"
+				>
+					<div class="space-y-4">
+						<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+							>Secciones</span
 						>
-							<div class="py-2">
-								{#each sections as item}
-									<a href={item.href} class="flex items-center px-4 py-3 text-gray-700 hover:bg-[#374993] hover:text-white transition group">
-										<div class={`w-8 h-8 rounded-full flex items-center justify-center mr-3`} style={`background-color: ${item.color}1A`}>
-											<div class="w-4 h-4 rounded-full" style={`background-color: ${item.color}`}></div>
+						<div class="grid gap-3">
+							{#each sections as section (section.href)}
+								<a
+									href={section.href}
+									class="flex items-center justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 transition hover:border-white/40 hover:bg-white/10"
+									style={`box-shadow: 0 12px 30px -18px ${section.color}bb;`}
+									onclick={() => (menuOpen = false)}
+								>
+									<div class="flex items-center gap-3">
+										<span
+											class="inline-flex h-9 w-9 items-center justify-center rounded-2xl border border-white/10"
+											style={`background:${section.color}1a;`}
+										>
+											<span class="h-2.5 w-2.5 rounded-full" style={`background:${section.color}`}
+											></span>
+										</span>
+										<div>
+											<p class="font-['Space_Grotesk'] text-sm font-semibold text-white">
+												{section.label}
+											</p>
+											<p class="font-['DM_Sans'] text-xs text-white/65">{section.description}</p>
 										</div>
-										<span class="font-['DM_Sans'] font-medium">{item.label}</span>
+									</div>
+									<svg
+										class="h-4 w-4 text-white/50"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.5"
+									>
+										<path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+									</svg>
+								</a>
+							{/each}
+						</div>
+					</div>
+
+					<div class="space-y-3">
+						<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+							>Más</span
+						>
+						<div class="grid gap-2">
+							{#each mainLinks as link (link.href)}
+								<a
+									href={link.href}
+									class="rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm font-medium text-white/80 transition hover:border-white/40 hover:bg-white/10 hover:text-white"
+									onclick={() => (menuOpen = false)}
+								>
+									{link.label}
+								</a>
+							{/each}
+							<a
+								href="/newsletter"
+								class="rounded-2xl bg-white px-4 py-3 text-center text-sm font-semibold tracking-[0.18em] text-slate-900 uppercase transition hover:bg-slate-100"
+								onclick={() => (menuOpen = false)}
+							>
+								Newsletter
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	<main class="relative flex min-h-screen flex-col pt-32">
+		<div class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+			<div
+				class="absolute top-[-20%] left-1/2 h-[480px] w-[720px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(136,55,140,0.28),_transparent_60%)] blur-3xl"
+			></div>
+			<div
+				class="absolute top-1/3 right-[-10%] h-[360px] w-[360px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(76,71,158,0.25),_transparent_65%)] blur-3xl"
+			></div>
+			<div
+				class="absolute bottom-[-10%] left-[-15%] h-[420px] w-[420px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(60,128,99,0.2),_transparent_60%)] blur-3xl"
+			></div>
+		</div>
+
+		{@render children()}
+
+		<footer class="mt-auto border-t border-white/5 bg-slate-950/80">
+			<div class="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+				<div class="grid gap-12 md:grid-cols-[1.2fr,0.8fr]">
+					<div class="space-y-6">
+						<a href="/" class="inline-flex items-center gap-3">
+							<span
+								class="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/5"
+							>
+								<img src="/logo.png" alt="Surcos" class="h-9 w-9" />
+							</span>
+							<div class="flex flex-col">
+								<span class="font-['Space_Grotesk'] text-lg font-semibold tracking-tight text-white"
+									>Surcos</span
+								>
+								<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-white/60 uppercase"
+									>Periodismo de izquierda</span
+								>
+							</div>
+						</a>
+						<p class="max-w-xl font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+							Historias, análisis y crónicas que atraviesan nuestros territorios. Una revista
+							digital independiente que amplifica las voces que abren nuevos horizontes.
+						</p>
+						<div class="flex flex-wrap gap-3">
+							{#each sections as section (section.href)}
+								<span
+									class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70"
+									style={`box-shadow: inset 0 0 0 1px ${section.color}55;`}
+								>
+									<span class="h-2 w-2 rounded-full" style={`background:${section.color}`}></span>
+									{section.label}
+								</span>
+							{/each}
+						</div>
+					</div>
+					<div class="grid gap-8 sm:grid-cols-2">
+						<div class="space-y-4">
+							<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+								>Explorar</span
+							>
+							<div class="grid gap-3">
+								{#each sections as section (section.href)}
+									<a
+										href={section.href}
+										class="group flex items-center justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm font-medium text-white/70 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
+									>
+										<span>{section.label}</span>
+										<svg
+											class="h-4 w-4 opacity-0 transition group-hover:opacity-100"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											stroke-width="1.5"
+										>
+											<path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+										</svg>
 									</a>
 								{/each}
 							</div>
 						</div>
-					{/if}
-				</div>
-
-				<a href="/nosotros" class="px-3 py-2 rounded-md hover:bg-white/10 transition font-medium font-['Space_Grotesk']">Nosotros</a>
-				<a href="/contacto" class="px-3 py-2 rounded-md hover:bg-white/10 transition font-medium font-['Space_Grotesk']">Contacto</a>
-			</div>
-
-			<!-- Mobile Menu Button -->
-			<button
-				class="md:hidden p-2 rounded-md hover:bg-white/10 transition focus:outline-none"
-				onclick={() => (menuOpen = !menuOpen)}
-				aria-label="Toggle mobile menu"
-				aria-expanded={menuOpen}
-			>
-				<svg class={`w-6 h-6 transition-transform duration-300 ${menuOpen ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-				</svg>
-			</button>
-		</div>
-	</div>
-
-	<!-- Mobile Menu -->
-	{#if menuOpen}
-		<div
-			in:slide={{ duration: 300 }}
-			out:slide={{ duration: 200 }}
-			class="md:hidden bg-[#2c3e50] border-t border-white/10"
-		>
-			<div class="px-4 py-4 space-y-3">
-				<!-- Mobile Dropdown -->
-				<div>
-					<button
-						onclick={() => (seccionesOpen = !seccionesOpen)}
-						class="flex justify-between items-center w-full px-3 py-2 rounded-md hover:bg-white/10 transition font-medium font-['Space_Grotesk']"
-						aria-haspopup="true"
-						aria-expanded={seccionesOpen}
-					>
-						<span>Secciones</span>
-						<svg class={`w-5 h-5 transition-transform ${seccionesOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-						</svg>
-					</button>
-
-					{#if seccionesOpen}
-						<div in:slide={{ duration: 200 }} out:slide={{ duration: 150 }} class="mt-2 ml-3 space-y-1">
-							{#each [
-								{ href: '/justicia', label: 'Justicia' },
-								{ href: '/desarrollo', label: 'Desigualdad' },
-								{ href: '/cultura', label: 'Cultura' },
-								{ href: '/politica', label: 'Política' },
-								{ href: '/medio-ambiente', label: 'Ambiente' }
-							] as item}
-								<a href={item.href} class="block px-3 py-2 text-white/80 hover:text-white hover:bg-white/5 rounded-md font-['DM_Sans']">{item.label}</a>
-							{/each}
+						<div class="space-y-4">
+							<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+								>Contacto</span
+							>
+							<div class="space-y-3">
+								{#each mainLinks as link (link.href)}
+									<a
+										href={link.href}
+										class="block rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm font-medium text-white/80 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
+									>
+										{link.label}
+									</a>
+								{/each}
+								<a
+									href="mailto:contacto@surcos.com"
+									class="block rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm font-medium text-white/80 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
+								>
+									contacto@surcos.com
+								</a>
+							</div>
 						</div>
-					{/if}
+					</div>
 				</div>
-
-				<a href="/nosotros" class="block px-3 py-2 text-white hover:bg-white/10 rounded-md font-medium font-['Space_Grotesk']">Nosotros</a>
-				<a href="/contacto" class="block px-3 py-2 text-white hover:bg-white/10 rounded-md font-medium font-['Space_Grotesk']">Contacto</a>
+				<div
+					class="mt-12 border-t border-white/5 pt-6 text-center font-['DM_Sans'] text-xs tracking-[0.32em] text-white/50 uppercase"
+				>
+					© {new Date().getFullYear()} Surcos. Todos los derechos reservados.
+				</div>
 			</div>
-		</div>
-	{/if}
-</nav>
-
-<main class="flex flex-col min-h-screen">
-	{@render children()}
-    <footer class="mt-auto">
-        <div class="bg-gradient-to-r from-[#C44949] to-[#B13E3E] text-white py-10">
-            <div class="max-w-4xl mx-auto px-4">
-                <div class="text-center">
-                    <p class="text-sm md:text-base font-['DM_Sans'] opacity-90">
-                        © {new Date().getFullYear()} Surcos. Todos los derechos reservados.
-                    </p>
-                </div>
-            </div>
-        </div>
-    </footer>
-</main>
-
-
+		</footer>
+	</main>
+</div>

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -58,23 +58,23 @@
 	});
 </script>
 
-<div class="relative min-h-screen bg-slate-950 text-slate-100">
+<div class="relative min-h-screen bg-[#f5efe6] text-slate-900">
 	<nav class="pointer-events-none fixed inset-x-0 top-0 z-50">
 		<div class="pointer-events-auto mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 			<div
-				class="mt-6 flex items-center justify-between rounded-3xl border border-white/10 bg-slate-900/70 px-5 py-4 shadow-2xl shadow-black/40 backdrop-blur-2xl"
+				class="mt-6 flex items-center justify-between rounded-3xl border border-slate-200/80 bg-white/90 px-5 py-4 shadow-lg shadow-slate-400/30 backdrop-blur"
 			>
 				<a href="/" class="flex items-center gap-3">
 					<span
-						class="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/5"
+						class="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-200 bg-white"
 					>
 						<img src="/logo.png" alt="Surcos" class="h-9 w-9" />
 					</span>
 					<div class="flex flex-col">
-						<span class="font-['Space_Grotesk'] text-lg font-semibold tracking-tight text-white"
+						<span class="font-['Space_Grotesk'] text-lg font-semibold tracking-tight text-slate-900"
 							>Surcos</span
 						>
-						<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-white/60 uppercase"
+						<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-slate-500 uppercase"
 							>Revista Digital</span
 						>
 					</div>
@@ -90,7 +90,7 @@
 						onfocusout={() => (showDropdown = false)}
 					>
 						<button
-							class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium tracking-wide text-white transition hover:border-white/30 hover:bg-white/10"
+							class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium tracking-wide text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 hover:text-slate-900"
 							aria-haspopup="true"
 							aria-controls="secciones-menu"
 							aria-expanded={showDropdown}
@@ -109,28 +109,28 @@
 
 						{#if showDropdown}
 							<div
-								class="absolute right-0 z-30 mt-4 w-96 rounded-3xl border border-white/10 bg-slate-900/95 p-4 shadow-2xl shadow-black/40 backdrop-blur-2xl"
+								class="absolute right-0 z-30 mt-4 w-96 rounded-3xl border border-slate-200 bg-white p-4 shadow-xl shadow-slate-400/30"
 								id="secciones-menu"
 							>
 								<div class="grid gap-3">
 									{#each sections as section (section.href)}
 										<a
 											href={section.href}
-											class="group flex items-start gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3 transition hover:border-white/30 hover:bg-white/10"
-											style={`box-shadow: 0 12px 30px -18px ${section.color}bb;`}
+											class="group flex items-start gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 transition hover:-translate-y-0.5 hover:border-slate-400 hover:shadow-md"
+											style={`box-shadow: 0 12px 24px -18px ${section.color}55;`}
 										>
 											<span
-												class="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl border border-white/10"
-												style={`background:${section.color}1a; color:${section.color};`}
+												class="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl border border-slate-200"
+												style={`background:${section.color}15; color:${section.color};`}
 											>
 												<span class="h-2.5 w-2.5 rounded-full" style={`background:${section.color}`}
 												></span>
 											</span>
 											<span class="flex flex-col">
-												<span class="font-['Space_Grotesk'] text-sm font-semibold text-white"
+												<span class="font-['Space_Grotesk'] text-sm font-semibold text-slate-900"
 													>{section.label}</span
 												>
-												<span class="font-['DM_Sans'] text-xs text-white/70"
+												<span class="font-['DM_Sans'] text-xs text-slate-600"
 													>{section.description}</span
 												>
 											</span>
@@ -144,7 +144,7 @@
 					{#each mainLinks as link (link.href)}
 						<a
 							href={link.href}
-							class="rounded-full border border-white/10 px-4 py-2 text-sm font-medium tracking-wide text-white/80 transition hover:border-white/30 hover:text-white"
+							class="rounded-full border border-transparent px-4 py-2 text-sm font-medium tracking-wide text-slate-700 transition hover:text-slate-900 hover:underline"
 						>
 							{link.label}
 						</a>
@@ -152,14 +152,14 @@
 
 					<a
 						href="/newsletter"
-						class="rounded-full bg-white px-4 py-2 text-sm font-semibold tracking-[0.18em] text-slate-900 uppercase transition hover:bg-slate-100"
+						class="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold tracking-[0.18em] text-white uppercase transition hover:bg-slate-700"
 					>
 						Newsletter
 					</a>
 				</div>
 
 				<button
-					class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white transition hover:border-white/30 hover:bg-white/10 lg:hidden"
+					class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 lg:hidden"
 					onclick={() => (menuOpen = !menuOpen)}
 					aria-label="Abrir menú"
 					aria-expanded={menuOpen}
@@ -186,43 +186,43 @@
 		<div class="fixed inset-0 z-40 lg:hidden">
 			<button
 				type="button"
-				class="absolute inset-0 h-full w-full cursor-pointer bg-slate-950/80 backdrop-blur-xl"
+				class="absolute inset-0 h-full w-full cursor-pointer bg-slate-900/20 backdrop-blur"
 				aria-label="Cerrar menú"
 				onclick={() => (menuOpen = false)}
 			></button>
 			<div class="relative mx-4 mt-28" in:slide={{ duration: 250 }} out:slide={{ duration: 200 }}>
 				<div
-					class="space-y-6 rounded-3xl border border-white/10 bg-slate-900/95 p-6 shadow-2xl shadow-black/40"
+					class="space-y-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-xl shadow-slate-400/30"
 				>
 					<div class="space-y-4">
-						<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+						<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-slate-500 uppercase"
 							>Secciones</span
 						>
 						<div class="grid gap-3">
 							{#each sections as section (section.href)}
 								<a
 									href={section.href}
-									class="flex items-center justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 transition hover:border-white/40 hover:bg-white/10"
-									style={`box-shadow: 0 12px 30px -18px ${section.color}bb;`}
+									class="flex items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-3 transition hover:-translate-y-0.5 hover:border-slate-400 hover:shadow-md"
+									style={`box-shadow: 0 12px 24px -18px ${section.color}55;`}
 									onclick={() => (menuOpen = false)}
 								>
 									<div class="flex items-center gap-3">
 										<span
-											class="inline-flex h-9 w-9 items-center justify-center rounded-2xl border border-white/10"
-											style={`background:${section.color}1a;`}
+											class="inline-flex h-9 w-9 items-center justify-center rounded-2xl border border-slate-200"
+											style={`background:${section.color}15;`}
 										>
 											<span class="h-2.5 w-2.5 rounded-full" style={`background:${section.color}`}
 											></span>
 										</span>
 										<div>
-											<p class="font-['Space_Grotesk'] text-sm font-semibold text-white">
+											<p class="font-['Space_Grotesk'] text-sm font-semibold text-slate-900">
 												{section.label}
 											</p>
-											<p class="font-['DM_Sans'] text-xs text-white/65">{section.description}</p>
+											<p class="font-['DM_Sans'] text-xs text-slate-600">{section.description}</p>
 										</div>
 									</div>
 									<svg
-										class="h-4 w-4 text-white/50"
+										class="h-4 w-4 text-slate-400"
 										viewBox="0 0 24 24"
 										fill="none"
 										stroke="currentColor"
@@ -236,14 +236,14 @@
 					</div>
 
 					<div class="space-y-3">
-						<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+						<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-slate-500 uppercase"
 							>Más</span
 						>
 						<div class="grid gap-2">
 							{#each mainLinks as link (link.href)}
 								<a
 									href={link.href}
-									class="rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm font-medium text-white/80 transition hover:border-white/40 hover:bg-white/10 hover:text-white"
+									class="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 hover:text-slate-900"
 									onclick={() => (menuOpen = false)}
 								>
 									{link.label}
@@ -251,7 +251,7 @@
 							{/each}
 							<a
 								href="/newsletter"
-								class="rounded-2xl bg-white px-4 py-3 text-center text-sm font-semibold tracking-[0.18em] text-slate-900 uppercase transition hover:bg-slate-100"
+								class="rounded-2xl bg-slate-900 px-4 py-3 text-center text-sm font-semibold tracking-[0.18em] text-white uppercase transition hover:bg-slate-700"
 								onclick={() => (menuOpen = false)}
 							>
 								Newsletter
@@ -263,48 +263,39 @@
 		</div>
 	{/if}
 
-	<main class="relative flex min-h-screen flex-col pt-32">
-		<div class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-			<div
-				class="absolute top-[-20%] left-1/2 h-[480px] w-[720px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(136,55,140,0.28),_transparent_60%)] blur-3xl"
-			></div>
-			<div
-				class="absolute top-1/3 right-[-10%] h-[360px] w-[360px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(76,71,158,0.25),_transparent_65%)] blur-3xl"
-			></div>
-			<div
-				class="absolute bottom-[-10%] left-[-15%] h-[420px] w-[420px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(60,128,99,0.2),_transparent_60%)] blur-3xl"
-			></div>
-		</div>
-
+	<main
+		class="relative flex min-h-screen flex-col bg-gradient-to-br from-[#f8f3ec] via-[#f5efe6] to-[#f1e7db] pt-32"
+	>
 		{@render children()}
 
-		<footer class="mt-auto border-t border-white/5 bg-slate-950/80">
+		<footer class="mt-auto border-t border-slate-200/70 bg-white/70">
 			<div class="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
 				<div class="grid gap-12 md:grid-cols-[1.2fr,0.8fr]">
 					<div class="space-y-6">
 						<a href="/" class="inline-flex items-center gap-3">
 							<span
-								class="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/5"
+								class="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-200 bg-white"
 							>
 								<img src="/logo.png" alt="Surcos" class="h-9 w-9" />
 							</span>
 							<div class="flex flex-col">
-								<span class="font-['Space_Grotesk'] text-lg font-semibold tracking-tight text-white"
+								<span
+									class="font-['Space_Grotesk'] text-lg font-semibold tracking-tight text-slate-900"
 									>Surcos</span
 								>
-								<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-white/60 uppercase"
+								<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-slate-500 uppercase"
 									>Periodismo de izquierda</span
 								>
 							</div>
 						</a>
-						<p class="max-w-xl font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+						<p class="max-w-xl font-['DM_Sans'] text-sm leading-relaxed text-slate-600">
 							Historias, análisis y crónicas que atraviesan nuestros territorios. Una revista
 							digital independiente que amplifica las voces que abren nuevos horizontes.
 						</p>
 						<div class="flex flex-wrap gap-3">
 							{#each sections as section (section.href)}
 								<span
-									class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70"
+									class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600"
 									style={`box-shadow: inset 0 0 0 1px ${section.color}55;`}
 								>
 									<span class="h-2 w-2 rounded-full" style={`background:${section.color}`}></span>
@@ -315,18 +306,18 @@
 					</div>
 					<div class="grid gap-8 sm:grid-cols-2">
 						<div class="space-y-4">
-							<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+							<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-slate-500 uppercase"
 								>Explorar</span
 							>
 							<div class="grid gap-3">
 								{#each sections as section (section.href)}
 									<a
 										href={section.href}
-										class="group flex items-center justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm font-medium text-white/70 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
+										class="group flex items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-slate-400 hover:bg-slate-100 hover:text-slate-900"
 									>
 										<span>{section.label}</span>
 										<svg
-											class="h-4 w-4 opacity-0 transition group-hover:opacity-100"
+											class="h-4 w-4 text-slate-400 opacity-0 transition group-hover:text-slate-600 group-hover:opacity-100"
 											viewBox="0 0 24 24"
 											fill="none"
 											stroke="currentColor"
@@ -339,21 +330,21 @@
 							</div>
 						</div>
 						<div class="space-y-4">
-							<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+							<span class="font-['DM_Sans'] text-xs tracking-[0.28em] text-slate-500 uppercase"
 								>Contacto</span
 							>
 							<div class="space-y-3">
 								{#each mainLinks as link (link.href)}
 									<a
 										href={link.href}
-										class="block rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm font-medium text-white/80 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
+										class="block rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 hover:text-slate-900"
 									>
 										{link.label}
 									</a>
 								{/each}
 								<a
 									href="mailto:contacto@surcos.com"
-									class="block rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm font-medium text-white/80 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
+									class="block rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 hover:text-slate-900"
 								>
 									contacto@surcos.com
 								</a>
@@ -362,7 +353,7 @@
 					</div>
 				</div>
 				<div
-					class="mt-12 border-t border-white/5 pt-6 text-center font-['DM_Sans'] text-xs tracking-[0.32em] text-white/50 uppercase"
+					class="mt-12 border-t border-slate-200/80 pt-6 text-center font-['DM_Sans'] text-xs tracking-[0.32em] text-slate-500 uppercase"
 				>
 					© {new Date().getFullYear()} Surcos. Todos los derechos reservados.
 				</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -75,32 +75,23 @@
 	];
 </script>
 
-<section class="relative isolate overflow-hidden">
-	<div class="absolute inset-0 -z-10">
-		<div
-			class="absolute top-[-40%] left-1/2 h-[620px] w-[620px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(196,73,73,0.28),_transparent_65%)] blur-3xl"
-		></div>
-		<div
-			class="absolute top-1/4 right-[-10%] h-[420px] w-[420px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(136,55,140,0.25),_transparent_70%)] blur-3xl"
-		></div>
-		<div
-			class="absolute bottom-[-20%] left-[-15%] h-[500px] w-[500px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(60,128,99,0.2),_transparent_70%)] blur-3xl"
-		></div>
-	</div>
+<section
+	class="relative isolate overflow-hidden bg-gradient-to-br from-[#f9f2e8] via-[#f6efe6] to-[#f2eadf]"
+>
 	<div class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pt-36 pb-24 sm:px-6 lg:px-8 lg:pt-40">
 		<div class="grid items-end gap-14 lg:grid-cols-[1.25fr,0.75fr]">
 			<div class="space-y-8 text-left">
 				<span
-					class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold tracking-[0.28em] text-white/70 uppercase backdrop-blur"
+					class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-1 text-xs font-semibold tracking-[0.28em] text-slate-500 uppercase"
 				>
 					Nueva temporada
 				</span>
 				<h1
-					class="font-['Space_Grotesk'] text-4xl leading-tight font-semibold text-white sm:text-5xl lg:text-6xl"
+					class="font-['Space_Grotesk'] text-4xl leading-tight font-semibold text-slate-900 sm:text-5xl lg:text-6xl"
 				>
 					Periodismo que abre caminos para imaginar otros futuros posibles.
 				</h1>
-				<p class="max-w-2xl font-['DM_Sans'] text-base leading-relaxed text-white/75 sm:text-lg">
+				<p class="max-w-2xl font-['DM_Sans'] text-base leading-relaxed text-slate-600 sm:text-lg">
 					Surcos es una revista digital que explora los cruces entre justicia social, cultura,
 					política y ambiente. Historias contadas con cuidado editorial, investigación rigurosa y
 					estética audiovisual.
@@ -108,67 +99,69 @@
 				<div class="flex flex-wrap gap-4">
 					<a
 						href="/justicia"
-						class="rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold tracking-[0.28em] text-white uppercase transition hover:border-white/40 hover:bg-white/20"
+						class="rounded-full border border-slate-900 px-6 py-3 text-xs font-semibold tracking-[0.28em] text-slate-900 uppercase transition hover:bg-slate-900 hover:text-white"
 					>
 						Explorar secciones
 					</a>
 					<a
 						href="/newsletter"
-						class="rounded-full bg-white px-6 py-3 text-xs font-semibold tracking-[0.28em] text-slate-900 uppercase transition hover:bg-slate-100"
+						class="rounded-full bg-slate-900 px-6 py-3 text-xs font-semibold tracking-[0.28em] text-white uppercase transition hover:bg-slate-700"
 					>
 						Suscribirme
 					</a>
 				</div>
 			</div>
-			<div class="space-y-6 rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl">
-				<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-white/60 uppercase"
+			<div
+				class="space-y-6 rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-300/40"
+			>
+				<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-slate-500 uppercase"
 					>Últimos lanzamientos</span
 				>
 				<div class="space-y-5">
 					<div class="flex items-start gap-4">
 						<span
-							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-white/10"
+							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-slate-200"
 							style="background:#88378C1a"
 						>
 							<span class="h-2.5 w-2.5 rounded-full" style="background:#88378C"></span>
 						</span>
 						<div class="space-y-1">
-							<p class="font-['Space_Grotesk'] text-sm font-semibold text-white">
+							<p class="font-['Space_Grotesk'] text-sm font-semibold text-slate-900">
 								Dossier audiovisual: memorias del sur
 							</p>
-							<p class="font-['DM_Sans'] text-sm text-white/70">
+							<p class="font-['DM_Sans'] text-sm text-slate-600">
 								Una serie de cortos que atraviesa músicas, rituales y luchas comunitarias.
 							</p>
 						</div>
 					</div>
 					<div class="flex items-start gap-4">
 						<span
-							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-white/10"
+							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-slate-200"
 							style="background:#3C80631a"
 						>
 							<span class="h-2.5 w-2.5 rounded-full" style="background:#3C8063"></span>
 						</span>
 						<div class="space-y-1">
-							<p class="font-['Space_Grotesk'] text-sm font-semibold text-white">
+							<p class="font-['Space_Grotesk'] text-sm font-semibold text-slate-900">
 								Informe interactivo: cartografías del cuidado
 							</p>
-							<p class="font-['DM_Sans'] text-sm text-white/70">
+							<p class="font-['DM_Sans'] text-sm text-slate-600">
 								Datos, relatos y visualizaciones sobre redes feministas que sostienen la vida.
 							</p>
 						</div>
 					</div>
 					<div class="flex items-start gap-4">
 						<span
-							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-white/10"
+							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-slate-200"
 							style="background:#C449491a"
 						>
 							<span class="h-2.5 w-2.5 rounded-full" style="background:#C44949"></span>
 						</span>
 						<div class="space-y-1">
-							<p class="font-['Space_Grotesk'] text-sm font-semibold text-white">
+							<p class="font-['Space_Grotesk'] text-sm font-semibold text-slate-900">
 								Newsletter quincenal
 							</p>
-							<p class="font-['DM_Sans'] text-sm text-white/70">
+							<p class="font-['DM_Sans'] text-sm text-slate-600">
 								Curaduría con lecturas recomendadas, agenda y avances de investigación.
 							</p>
 						</div>
@@ -186,15 +179,15 @@
 		>
 			<div>
 				<span
-					class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1 text-xs font-semibold tracking-[0.28em] text-white/60 uppercase"
+					class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-1 text-xs font-semibold tracking-[0.28em] text-slate-500 uppercase"
 				>
 					Nuestros ejes
 				</span>
-				<h2 class="mt-4 font-['Space_Grotesk'] text-3xl font-semibold text-white sm:text-4xl">
+				<h2 class="mt-4 font-['Space_Grotesk'] text-3xl font-semibold text-slate-900 sm:text-4xl">
 					Cinco secciones para narrar las fisuras y los deseos de una nueva época.
 				</h2>
 			</div>
-			<p class="max-w-xl font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+			<p class="max-w-xl font-['DM_Sans'] text-sm leading-relaxed text-slate-600">
 				Cada texto, foto, podcast y visualización se construye junto a las comunidades
 				protagonistas. Investigamos, contamos historias y diseñamos experiencias digitales que
 				acompañan los cambios en marcha.
@@ -205,23 +198,23 @@
 			{#each sectionCards as card (card.href)}
 				<a
 					href={card.href}
-					class="group relative flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-7 backdrop-blur-xl transition hover:-translate-y-2 hover:border-white/40 hover:bg-white/10"
-					style={`box-shadow: 0 20px 40px -25px ${card.accent}cc;`}
+					class="group relative flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white p-7 shadow-md shadow-slate-300/30 transition hover:-translate-y-2 hover:border-slate-400 hover:shadow-xl"
+					style={`box-shadow: 0 20px 40px -25px ${card.accent}55;`}
 				>
 					<div class="space-y-5">
 						<span
-							class="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-medium text-white/70"
+							class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600"
 							style={`background:${card.accent}1a;`}
 						>
 							<span class="h-2 w-2 rounded-full" style={`background:${card.accent}`}></span>
 							{card.title}
 						</span>
-						<p class="font-['Space_Grotesk'] text-xl font-semibold text-white">
+						<p class="font-['Space_Grotesk'] text-xl font-semibold text-slate-900">
 							{card.description}
 						</p>
 					</div>
 					<span
-						class="mt-8 inline-flex items-center gap-2 font-['DM_Sans'] text-sm font-medium text-white/80 transition group-hover:gap-3 group-hover:text-white"
+						class="mt-8 inline-flex items-center gap-2 font-['DM_Sans'] text-sm font-medium text-slate-600 transition group-hover:gap-3 group-hover:text-slate-900"
 					>
 						Leer más
 						<svg
@@ -244,50 +237,52 @@
 	<div class="mx-auto max-w-6xl">
 		<div class="grid gap-12 lg:grid-cols-[1.1fr,0.9fr]">
 			<div
-				class="space-y-8 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-white/10 p-10 backdrop-blur-xl"
+				class="space-y-8 rounded-3xl border border-slate-200 bg-white p-10 shadow-lg shadow-slate-300/40"
 			>
 				{#each featureHighlights as feature (feature.title)}
 					<article
-						class="rounded-3xl border border-white/10 bg-slate-950/40 p-8 transition hover:border-white/40 hover:bg-slate-950/60"
-						style={`box-shadow: 0 18px 40px -24px ${feature.accent}cc;`}
+						class="rounded-3xl border border-slate-200 bg-[#f5efe6] p-8 transition hover:-translate-y-1 hover:border-slate-400 hover:shadow-lg"
+						style={`box-shadow: 0 18px 40px -24px ${feature.accent}55;`}
 					>
 						<span
-							class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+							class="font-['DM_Sans'] text-xs tracking-[0.28em] uppercase"
 							style={`letter-spacing:0.28em; color:${feature.accent};`}
 						>
 							{feature.eyebrow}
 						</span>
-						<h3 class="mt-4 font-['Space_Grotesk'] text-2xl font-semibold text-white sm:text-3xl">
+						<h3
+							class="mt-4 font-['Space_Grotesk'] text-2xl font-semibold text-slate-900 sm:text-3xl"
+						>
 							{feature.title}
 						</h3>
-						<p class="mt-3 font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+						<p class="mt-3 font-['DM_Sans'] text-sm leading-relaxed text-slate-600">
 							{feature.description}
 						</p>
 					</article>
 				{/each}
 			</div>
 			<div class="space-y-8">
-				<div class="rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl">
-					<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-white/60 uppercase"
+				<div class="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-300/40">
+					<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-slate-500 uppercase"
 						>Editorial</span
 					>
-					<h3 class="mt-4 font-['Space_Grotesk'] text-2xl font-semibold text-white">
+					<h3 class="mt-4 font-['Space_Grotesk'] text-2xl font-semibold text-slate-900">
 						Tres líneas que guían nuestra mirada.
 					</h3>
 					<div class="mt-8 space-y-6">
 						{#each editorialNotes as note (note.title)}
 							<div
-								class="rounded-2xl border border-white/10 bg-slate-950/40 p-6"
-								style={`box-shadow: 0 14px 30px -24px ${note.accent}cc;`}
+								class="rounded-2xl border border-slate-200 bg-[#f5efe6] p-6"
+								style={`box-shadow: 0 14px 30px -24px ${note.accent}55;`}
 							>
 								<span
-									class="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-medium text-white/70"
+									class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600"
 									style={`background:${note.accent}1a;`}
 								>
 									<span class="h-2 w-2 rounded-full" style={`background:${note.accent}`}></span>
 									{note.title}
 								</span>
-								<p class="mt-4 font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+								<p class="mt-4 font-['DM_Sans'] text-sm leading-relaxed text-slate-600">
 									{note.description}
 								</p>
 							</div>
@@ -295,18 +290,18 @@
 					</div>
 				</div>
 				<div
-					class="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/20 to-white/10 p-8 text-center backdrop-blur-xl"
+					class="rounded-3xl border border-slate-200 bg-[#f5efe6] p-8 text-center shadow-lg shadow-slate-300/40"
 				>
-					<h3 class="font-['Space_Grotesk'] text-2xl font-semibold text-white">
+					<h3 class="font-['Space_Grotesk'] text-2xl font-semibold text-slate-900">
 						Sumate a nuestra comunidad
 					</h3>
-					<p class="mt-3 font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+					<p class="mt-3 font-['DM_Sans'] text-sm leading-relaxed text-slate-600">
 						Recibí adelantos, materiales descargables y convocatorias abiertas para participar en
 						nuestras coberturas colaborativas.
 					</p>
 					<a
 						href="/newsletter"
-						class="mt-8 inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-xs font-semibold tracking-[0.28em] text-slate-900 uppercase transition hover:bg-slate-100"
+						class="mt-8 inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-xs font-semibold tracking-[0.28em] text-white uppercase transition hover:bg-slate-700"
 					>
 						Suscribirme
 						<svg

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,65 +1,325 @@
 <script>
-	
+	const sectionCards = [
+		{
+			title: 'Justicia',
+			accent: '#3C8063',
+			description:
+				'Seguimos los juicios, políticas públicas y luchas territoriales que garantizan derechos y reparaciones.',
+			href: '/justicia'
+		},
+		{
+			title: 'Desigualdad',
+			accent: '#88378C',
+			description:
+				'Economía popular, redes comunitarias y nuevas formas de organización frente a la concentración.',
+			href: '/desarrollo'
+		},
+		{
+			title: 'Cultura',
+			accent: '#4F449E',
+			description:
+				'Expresiones artísticas, memoria y lenguajes emergentes que expanden lo posible.',
+			href: '/cultura'
+		},
+		{
+			title: 'Política',
+			accent: '#C44949',
+			description:
+				'Crónicas, análisis y protagonistas de los movimientos que disputan el sentido de lo público.',
+			href: '/politica'
+		},
+		{
+			title: 'Ambiente',
+			accent: '#B13E3E',
+			description:
+				'Clima, extractivismos y alternativas desde los territorios para defender lo común.',
+			href: '/medio-ambiente'
+		}
+	];
+
+	const featureHighlights = [
+		{
+			eyebrow: 'Crónica destacada',
+			title: 'Cuando la justicia llega tarde: historias mínimas desde los barrios populares',
+			description:
+				'Un recorrido por testimonios que reconstruyen cómo se teje la esperanza ante la demora del Estado.',
+			accent: '#3C8063'
+		},
+		{
+			eyebrow: 'Entrevista exclusiva',
+			title: 'Tecnopolítica en disputa: imaginación colectiva para gobernar lo digital',
+			description:
+				'Conversamos con investigadoras y militantes que proponen regulaciones democráticas y abiertas.',
+			accent: '#88378C'
+		}
+	];
+
+	const editorialNotes = [
+		{
+			title: 'Radar de lecturas imprescindibles',
+			description: 'Un mapa curado de columnas y podcasts que dialogan con nuestros territorios.',
+			accent: '#4F449E'
+		},
+		{
+			title: 'Mirada federal',
+			description:
+				'Una cobertura itinerante que acompaña luchas, celebraciones y resistencias en todo el país.',
+			accent: '#C44949'
+		},
+		{
+			title: 'Agenda verde',
+			description:
+				'Investigaciones y datos para actuar frente a la crisis climática desde la justicia social.',
+			accent: '#B13E3E'
+		}
+	];
 </script>
 
-<header class="text-center py-28 px-4 grow-0 bg-[#88378C] text-white relative overflow-hidden">
-	<img
-		src="/header.png"
-		alt="Surcos Logo"
-		class="mx-auto mb-12 w-72 md:w-96 max-w-full h-auto drop-shadow-lg transition-transform duration-300 hover:scale-105"
-	/>
-	<div class="max-w-2xl mx-auto">
-		<p class="text-2xl md:text-3xl lg:text-4xl font-['DM_Sans'] font-light tracking-wide leading-relaxed">
-			Periodismo de izquierda –<br class="hidden sm:block">
-			<span class="italic font-normal">No esa, la otra.</span>
-		</p>
+<section class="relative isolate overflow-hidden">
+	<div class="absolute inset-0 -z-10">
+		<div
+			class="absolute top-[-40%] left-1/2 h-[620px] w-[620px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(196,73,73,0.28),_transparent_65%)] blur-3xl"
+		></div>
+		<div
+			class="absolute top-1/4 right-[-10%] h-[420px] w-[420px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(136,55,140,0.25),_transparent_70%)] blur-3xl"
+		></div>
+		<div
+			class="absolute bottom-[-20%] left-[-15%] h-[500px] w-[500px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(60,128,99,0.2),_transparent_70%)] blur-3xl"
+		></div>
 	</div>
-</header>
-
-<!-- Enhanced main content section -->
-<section class="flex-grow bg-gradient-to-b from-gray-50 to-white">
-	<div class="max-w-4xl mx-auto px-4 py-20 text-center">
-		<!-- Section title with improved typography -->
-		<div class="mb-12">
-			<h2 class="text-3xl md:text-4xl lg:text-5xl text-[#3C8063] font-['Space_Grotesk'] font-bold mb-6 tracking-tight">
-				Nuestros Ejes
-			</h2>
-			<div class="w-24 h-1 bg-[#3C8063] mx-auto rounded-full"></div>
+	<div class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pt-36 pb-24 sm:px-6 lg:px-8 lg:pt-40">
+		<div class="grid items-end gap-14 lg:grid-cols-[1.25fr,0.75fr]">
+			<div class="space-y-8 text-left">
+				<span
+					class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold tracking-[0.28em] text-white/70 uppercase backdrop-blur"
+				>
+					Nueva temporada
+				</span>
+				<h1
+					class="font-['Space_Grotesk'] text-4xl leading-tight font-semibold text-white sm:text-5xl lg:text-6xl"
+				>
+					Periodismo que abre caminos para imaginar otros futuros posibles.
+				</h1>
+				<p class="max-w-2xl font-['DM_Sans'] text-base leading-relaxed text-white/75 sm:text-lg">
+					Surcos es una revista digital que explora los cruces entre justicia social, cultura,
+					política y ambiente. Historias contadas con cuidado editorial, investigación rigurosa y
+					estética audiovisual.
+				</p>
+				<div class="flex flex-wrap gap-4">
+					<a
+						href="/justicia"
+						class="rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold tracking-[0.28em] text-white uppercase transition hover:border-white/40 hover:bg-white/20"
+					>
+						Explorar secciones
+					</a>
+					<a
+						href="/newsletter"
+						class="rounded-full bg-white px-6 py-3 text-xs font-semibold tracking-[0.28em] text-slate-900 uppercase transition hover:bg-slate-100"
+					>
+						Suscribirme
+					</a>
+				</div>
+			</div>
+			<div class="space-y-6 rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl">
+				<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-white/60 uppercase"
+					>Últimos lanzamientos</span
+				>
+				<div class="space-y-5">
+					<div class="flex items-start gap-4">
+						<span
+							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-white/10"
+							style="background:#88378C1a"
+						>
+							<span class="h-2.5 w-2.5 rounded-full" style="background:#88378C"></span>
+						</span>
+						<div class="space-y-1">
+							<p class="font-['Space_Grotesk'] text-sm font-semibold text-white">
+								Dossier audiovisual: memorias del sur
+							</p>
+							<p class="font-['DM_Sans'] text-sm text-white/70">
+								Una serie de cortos que atraviesa músicas, rituales y luchas comunitarias.
+							</p>
+						</div>
+					</div>
+					<div class="flex items-start gap-4">
+						<span
+							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-white/10"
+							style="background:#3C80631a"
+						>
+							<span class="h-2.5 w-2.5 rounded-full" style="background:#3C8063"></span>
+						</span>
+						<div class="space-y-1">
+							<p class="font-['Space_Grotesk'] text-sm font-semibold text-white">
+								Informe interactivo: cartografías del cuidado
+							</p>
+							<p class="font-['DM_Sans'] text-sm text-white/70">
+								Datos, relatos y visualizaciones sobre redes feministas que sostienen la vida.
+							</p>
+						</div>
+					</div>
+					<div class="flex items-start gap-4">
+						<span
+							class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-white/10"
+							style="background:#C449491a"
+						>
+							<span class="h-2.5 w-2.5 rounded-full" style="background:#C44949"></span>
+						</span>
+						<div class="space-y-1">
+							<p class="font-['Space_Grotesk'] text-sm font-semibold text-white">
+								Newsletter quincenal
+							</p>
+							<p class="font-['DM_Sans'] text-sm text-white/70">
+								Curaduría con lecturas recomendadas, agenda y avances de investigación.
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
-		
-		<!-- Enhanced content with better spacing and readability -->
-		<div class="max-w-3xl mx-auto">
-			<p class="text-lg md:text-xl lg:text-2xl text-gray-700 leading-relaxed font-['DM_Sans'] font-light tracking-wide">
-				Exploramos temas desde una perspectiva crítica: derechos humanos, desarrollo, cultura,
-				política y más. Contribuimos a la transformación social con información, análisis y reflexión.
+	</div>
+</section>
+
+<section class="relative px-6 py-24 sm:px-6 lg:px-8">
+	<div class="mx-auto max-w-6xl space-y-12">
+		<div
+			class="flex flex-col items-start gap-6 text-left lg:flex-row lg:items-end lg:justify-between"
+		>
+			<div>
+				<span
+					class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1 text-xs font-semibold tracking-[0.28em] text-white/60 uppercase"
+				>
+					Nuestros ejes
+				</span>
+				<h2 class="mt-4 font-['Space_Grotesk'] text-3xl font-semibold text-white sm:text-4xl">
+					Cinco secciones para narrar las fisuras y los deseos de una nueva época.
+				</h2>
+			</div>
+			<p class="max-w-xl font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+				Cada texto, foto, podcast y visualización se construye junto a las comunidades
+				protagonistas. Investigamos, contamos historias y diseñamos experiencias digitales que
+				acompañan los cambios en marcha.
 			</p>
 		</div>
-		
-		<!-- Optional: Add some visual elements -->
-		<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-16 max-w-2xl mx-auto">
-			<div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow duration-300">
-				<div class="w-12 h-12 bg-[#3C8063]/10 rounded-full flex items-center justify-center mx-auto mb-3">
-					<div class="w-6 h-6 bg-[#3C8063] rounded-full"></div>
-				</div>
-				<p class="text-sm font-['DM_Sans'] text-gray-600">Derechos</p>
+
+		<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+			{#each sectionCards as card (card.href)}
+				<a
+					href={card.href}
+					class="group relative flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-7 backdrop-blur-xl transition hover:-translate-y-2 hover:border-white/40 hover:bg-white/10"
+					style={`box-shadow: 0 20px 40px -25px ${card.accent}cc;`}
+				>
+					<div class="space-y-5">
+						<span
+							class="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-medium text-white/70"
+							style={`background:${card.accent}1a;`}
+						>
+							<span class="h-2 w-2 rounded-full" style={`background:${card.accent}`}></span>
+							{card.title}
+						</span>
+						<p class="font-['Space_Grotesk'] text-xl font-semibold text-white">
+							{card.description}
+						</p>
+					</div>
+					<span
+						class="mt-8 inline-flex items-center gap-2 font-['DM_Sans'] text-sm font-medium text-white/80 transition group-hover:gap-3 group-hover:text-white"
+					>
+						Leer más
+						<svg
+							class="h-4 w-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+						>
+							<path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+						</svg>
+					</span>
+				</a>
+			{/each}
+		</div>
+	</div>
+</section>
+
+<section class="relative overflow-hidden px-6 pb-24 sm:px-6 lg:px-8">
+	<div class="mx-auto max-w-6xl">
+		<div class="grid gap-12 lg:grid-cols-[1.1fr,0.9fr]">
+			<div
+				class="space-y-8 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-white/10 p-10 backdrop-blur-xl"
+			>
+				{#each featureHighlights as feature (feature.title)}
+					<article
+						class="rounded-3xl border border-white/10 bg-slate-950/40 p-8 transition hover:border-white/40 hover:bg-slate-950/60"
+						style={`box-shadow: 0 18px 40px -24px ${feature.accent}cc;`}
+					>
+						<span
+							class="font-['DM_Sans'] text-xs tracking-[0.28em] text-white/60 uppercase"
+							style={`letter-spacing:0.28em; color:${feature.accent};`}
+						>
+							{feature.eyebrow}
+						</span>
+						<h3 class="mt-4 font-['Space_Grotesk'] text-2xl font-semibold text-white sm:text-3xl">
+							{feature.title}
+						</h3>
+						<p class="mt-3 font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+							{feature.description}
+						</p>
+					</article>
+				{/each}
 			</div>
-			<div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow duration-300">
-				<div class="w-12 h-12 bg-[#88378C]/10 rounded-full flex items-center justify-center mx-auto mb-3">
-					<div class="w-6 h-6 bg-[#88378C] rounded-full"></div>
+			<div class="space-y-8">
+				<div class="rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl">
+					<span class="font-['DM_Sans'] text-xs tracking-[0.32em] text-white/60 uppercase"
+						>Editorial</span
+					>
+					<h3 class="mt-4 font-['Space_Grotesk'] text-2xl font-semibold text-white">
+						Tres líneas que guían nuestra mirada.
+					</h3>
+					<div class="mt-8 space-y-6">
+						{#each editorialNotes as note (note.title)}
+							<div
+								class="rounded-2xl border border-white/10 bg-slate-950/40 p-6"
+								style={`box-shadow: 0 14px 30px -24px ${note.accent}cc;`}
+							>
+								<span
+									class="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-medium text-white/70"
+									style={`background:${note.accent}1a;`}
+								>
+									<span class="h-2 w-2 rounded-full" style={`background:${note.accent}`}></span>
+									{note.title}
+								</span>
+								<p class="mt-4 font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+									{note.description}
+								</p>
+							</div>
+						{/each}
+					</div>
 				</div>
-				<p class="text-sm font-['DM_Sans'] text-gray-600">Cultura</p>
-			</div>
-			<div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow duration-300">
-				<div class="w-12 h-12 bg-[#4F449E]/10 rounded-full flex items-center justify-center mx-auto mb-3">
-					<div class="w-6 h-6 bg-[#4F449E] rounded-full"></div>
+				<div
+					class="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/20 to-white/10 p-8 text-center backdrop-blur-xl"
+				>
+					<h3 class="font-['Space_Grotesk'] text-2xl font-semibold text-white">
+						Sumate a nuestra comunidad
+					</h3>
+					<p class="mt-3 font-['DM_Sans'] text-sm leading-relaxed text-white/70">
+						Recibí adelantos, materiales descargables y convocatorias abiertas para participar en
+						nuestras coberturas colaborativas.
+					</p>
+					<a
+						href="/newsletter"
+						class="mt-8 inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-xs font-semibold tracking-[0.28em] text-slate-900 uppercase transition hover:bg-slate-100"
+					>
+						Suscribirme
+						<svg
+							class="h-4 w-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+						>
+							<path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+						</svg>
+					</a>
 				</div>
-				<p class="text-sm font-['DM_Sans'] text-gray-600">Política</p>
-			</div>
-			<div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow duration-300">
-				<div class="w-12 h-12 bg-[#C44949]/10 rounded-full flex items-center justify-center mx-auto mb-3">
-					<div class="w-6 h-6 bg-[#C44949] rounded-full"></div>
-				</div>
-				<p class="text-sm font-['DM_Sans'] text-gray-600">Desarrollo</p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- replace the layout navigation with a glassmorphism-inspired header, mobile overlay, and rich footer that surface section colors and newsletter CTA
- redesign the home page with a dark magazine hero, color-coded section cards, and feature/editorial highlights tuned to each axis
- add accessibility touches to interactive wrappers while preserving the responsive dropdown menu behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb608c73e8832cace4bcc1b312ad9d